### PR TITLE
Add Blog tab and Building in Public daily-post series

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,8 @@ plugins:
   - jekyll-feed
 
 header_pages:
+  - blog.markdown
+  - building-in-public.markdown
   - projects.markdown
   - books.markdown
   - about.markdown

--- a/_posts/2026-07-14-building-in-public-day-1.md
+++ b/_posts/2026-07-14-building-in-public-day-1.md
@@ -5,8 +5,8 @@ date:   2026-07-14 09:00:00 +0200
 categories: building-in-public
 ---
 
-I'm going to build in the open. Every day I'll post a short entry documenting the work of building a real business — what I shipped, what I learned, what worked, and what didn't.
+I'm going to build in the open. Every day I'll post a short entry documenting the work of building a real business: what I shipped, what I learned, what worked, and what didn't.
 
-The rules are simple: one post a day, honest numbers, no polishing away the hard parts. The metric I'm using to know I've made something people actually want is $20,000 in monthly recurring revenue — not the goal itself, just the proof.
+The rules are simple: one post a day, numbers, no polishing away the hard parts. The metric I'm using to know I've made something people actually want is $20,000 in monthly recurring.
 
 This is day one. Let's see where it goes.

--- a/_posts/2026-07-14-building-in-public-day-1.md
+++ b/_posts/2026-07-14-building-in-public-day-1.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "Building in Public: Day 1"
+date:   2026-07-14 09:00:00 +0200
+categories: building-in-public
+---
+
+I'm going to build in the open. Every day I'll post a short entry documenting the work of building a real business — what I shipped, what I learned, what worked, and what didn't.
+
+The rules are simple: one post a day, honest numbers, no polishing away the hard parts. The metric I'm using to know I've made something people actually want is $20,000 in monthly recurring revenue — not the goal itself, just the proof.
+
+This is day one. Let's see where it goes.

--- a/blog.markdown
+++ b/blog.markdown
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Blog
+permalink: /blog/
+---
+
+Thoughts on building products, startups, and whatever else is on my mind. I'm also [Building in Public]({{ "/building-in-public/" | relative_url }}) with daily posts.
+
+<ul class="post-list">
+  {% for post in site.posts %}
+  <li>
+    <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+    </h3>
+  </li>
+  {% endfor %}
+</ul>

--- a/building-in-public.markdown
+++ b/building-in-public.markdown
@@ -1,0 +1,25 @@
+---
+layout: page
+title: Building in Public
+permalink: /building-in-public/
+---
+
+I'm building a business in the open, one daily post at a time — what I ship, what I learn, what works and what doesn't.
+
+The yardstick I'm holding myself to is **$20,000 in monthly recurring revenue**. It's not the point in itself, just the metric that tells me I've built something people genuinely want. Start at day one and read forward.
+
+{% assign journey = site.categories['building-in-public'] | sort: 'date' %}
+{% if journey.size > 0 %}
+<ul class="post-list">
+  {% for post in journey %}
+  <li>
+    <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+    </h3>
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+_The first entry is coming soon._
+{% endif %}

--- a/building-in-public.markdown
+++ b/building-in-public.markdown
@@ -4,9 +4,9 @@ title: Building in Public
 permalink: /building-in-public/
 ---
 
-I'm building a business in the open, one daily post at a time — what I ship, what I learn, what works and what doesn't.
+I'm building a business in the open, one daily post at a time: what I ship, what I learn, what works and what doesn't.
 
-The yardstick I'm holding myself to is **$20,000 in monthly recurring revenue**. It's not the point in itself, just the metric that tells me I've built something people genuinely want. Start at day one and read forward.
+The yardstick I'm holding myself to is **$20,000 in monthly recurring revenue**. It's just a metric that tells me I've built something people genuinely want. Start at day one and read forward.
 
 {% assign journey = site.categories['building-in-public'] | sort: 'date' %}
 {% if journey.size > 0 %}


### PR DESCRIPTION
## Summary

Adds a general blog listing and a dedicated "Building in Public" journey, with two new nav tabs.

### Blog
- New `blog.markdown` at `/blog/` listing all posts, plus a **Blog** nav tab.

### Building in Public
- New `building-in-public.markdown` at `/building-in-public/` that shows the daily journey posts **in sequence** (oldest → newest), plus a **Building in Public** nav tab.
- The **$20k MRR** target lives inside the page as the metric we're tracking — framed as the proof of having built something people want, not as the section's identity.
- Daily posts use the `building-in-public` category, so each one appears **both** in the general blog and in the dedicated sequence view. Jekyll's default permalinks also give them clean URLs like `/building-in-public/2026/07/14/...`.
- Includes a kickoff **Day 1** post that doubles as the template for future daily entries — edit or replace it as you like.

Nav order is now: Blog · Building in Public · Projects · Books · About.

Verified locally with a `jekyll build`: all five nav tabs render, and the Day 1 post appears in both the sequenced Building in Public page and the general Blog list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFHgvMMMfDHHpsZBeEnE4W)_