### PR TITLE
Simplify footer and add imprint page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,28 @@
+<footer class="site-footer h-card">
+  <data class="u-url" href="{{ "/" | relative_url }}"></data>
+
+  <div class="wrapper">
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col footer-col-1">
+        <ul class="contact-list">
+          {%- if site.author.email -%}
+          <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
+          {%- endif -%}
+        </ul>
+      </div>
+
+      <div class="footer-col footer-col-2">
+        {%- include social.html -%}
+      </div>
+
+      <div class="footer-col footer-col-3">
+        <p>{{ site.description | escape }}</p>
+      </div>
+    </div>
+
+    <p class="footer-legal">&copy; {{ site.time | date: '%Y' }} {{ site.title | escape }} &middot; <a href="{{ '/imprint/' | relative_url }}">Imprint</a></p>
+
+  </div>
+
+</footer>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,15 @@
+---
+---
+
+@import "minima";
+
+.footer-legal {
+  font-size: $small-font-size;
+  color: $brand-color;
+  margin-top: 15px;
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+}

--- a/imprint.markdown
+++ b/imprint.markdown
@@ -1,0 +1,33 @@
+---
+layout: page
+title: Imprint
+permalink: /imprint/
+---
+
+## Service Provider
+
+Tobias Wirtz Products
+Hagelberger Str. 10
+10965 Berlin, Germany
+
+**Contact:** [contact@magellink.com](mailto:contact@magellink.com)
+
+**Legal representative:** Tobias Wirtz
+
+**VAT identification number:** pending
+
+## Content Responsibility
+
+Responsible for content according to § 55 Abs. 2 RStV: Tobias Wirtz (address as above).
+
+## Liability for Content
+
+As a service provider, we are responsible for our own content on these pages in accordance with general law. However, we are not obligated to monitor transmitted or stored third-party information or to investigate circumstances that indicate illegal activity. Obligations to remove or block the use of information under general law remain unaffected.
+
+## Liability for Links
+
+Our site contains links to external third-party websites over whose content we have no influence. We therefore cannot assume any liability for such external content. The respective provider or operator of the linked pages is always responsible for their content.
+
+## Copyright
+
+The content and works created by the site operator are subject to copyright law. Reproduction, editing, distribution, or any form of use outside the limits of copyright law requires the prior written consent of the respective author.


### PR DESCRIPTION
The footer repeated the site name twice (heading + author line) on
top of the header already showing it. Trim that down to a single
copyright line and add an imprint page, linked from the footer.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TkXeWe8usDkw3UoXFyQp2d