### PR TITLE
Move footer copyright/imprint into the same row as other footer content

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,6 +9,7 @@
           {%- if site.author.email -%}
           <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
           {%- endif -%}
+          <li class="footer-legal">&copy; {{ site.time | date: '%Y' }} {{ site.title | escape }} &middot; <a href="{{ '/imprint/' | relative_url }}">Imprint</a></li>
         </ul>
       </div>
 
@@ -20,8 +21,6 @@
         <p>{{ site.description | escape }}</p>
       </div>
     </div>
-
-    <p class="footer-legal">&copy; {{ site.time | date: '%Y' }} {{ site.title | escape }} &middot; <a href="{{ '/imprint/' | relative_url }}">Imprint</a></p>
 
   </div>
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,9 +4,7 @@
 @import "minima";
 
 .footer-legal {
-  font-size: $small-font-size;
-  color: $brand-color;
-  margin-top: 15px;
+  margin-top: 5px;
 
   a {
     color: inherit;


### PR DESCRIPTION
## Summary
- Moves the copyright/imprint line that was previously on its own row below the footer columns up into the contact-list column, so it sits in the same footer row as the email, social links, and description.
- Adjusts the `.footer-legal` styling to fit inline within that column instead of as a standalone line.

## Test plan
- [x] Built the site locally with Jekyll (Ruby 3.1.6, matching the deploy workflow) and confirmed the footer renders with the copyright/imprint text inside the same row as the other footer columns.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TkXeWe8usDkw3UoXFyQp2d)_