### PR TITLE
Replace footer's fragile float columns with a flex layout

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,23 +3,15 @@
 
   <div class="wrapper footer-row">
 
-    <div class="footer-col-wrapper">
-      <div class="footer-col footer-col-1">
-        <ul class="contact-list">
-          {%- if site.author.email -%}
-          <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
-          {%- endif -%}
-        </ul>
-      </div>
+    <ul class="contact-list">
+      {%- if site.author.email -%}
+      <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
+      {%- endif -%}
+    </ul>
 
-      <div class="footer-col footer-col-2">
-        {%- include social.html -%}
-      </div>
+    {%- include social.html -%}
 
-      <div class="footer-col footer-col-3">
-        <p>{{ site.description | escape }}</p>
-      </div>
-    </div>
+    <p class="footer-description">{{ site.description | escape }}</p>
 
     <p class="footer-legal">&copy; {{ site.time | date: '%Y' }} {{ site.title | escape }} &middot; <a href="{{ '/imprint/' | relative_url }}">Imprint</a></p>
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,23 +4,22 @@
 @import "minima";
 
 .footer-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: start;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: $spacing-unit;
+  row-gap: 5px;
+  @include relative-font-size(0.9375);
+  color: $grey-color;
+}
 
-  @include media-query($on-palm) {
-    grid-template-columns: 1fr;
-  }
+.footer-description {
+  margin: 0;
 }
 
 .footer-legal {
-  @include relative-font-size(0.9375);
-  color: $grey-color;
+  margin: 0 0 0 auto;
   white-space: nowrap;
-
-  @include media-query($on-palm) {
-    margin-top: $spacing-unit / 2;
-  }
 
   a {
     color: inherit;


### PR DESCRIPTION
## Summary
- Found the real bug behind the "not in one line" footer: minima's theme sizes its footer columns with fixed percentages (35/20/45, becoming 50/50/45 past the 800px breakpoint). 50%+50% already fills the row, so the description column gets shoved onto its own line at viewport widths roughly between 600–800px — this was always true of the theme, it just became visible once the copyright/imprint text sat at the top of that broken row.
- Removed the float/percentage column system entirely and replaced it with a single `display: flex; flex-wrap: wrap;` row. Content now reflows based on actual available space instead of an arbitrary fixed split, and the copyright/imprint is pushed right via `margin-left: auto` (staying right-aligned even if it wraps to its own line on narrow screens).

## Test plan
- [x] Built the site locally with Jekyll (Ruby 3.1.6, matching the deploy workflow).
- [x] Screenshotted the footer with a headless browser across 320, 375, 480, 600, 601, 700, 800, 900, 1024, 1280, and 1440px widths — confirmed it's a single line whenever content fits, and wraps cleanly (still right-aligned) when it doesn't, with no more broken in-between states.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TkXeWe8usDkw3UoXFyQp2d)_